### PR TITLE
Set limit of max concurrent BURP AI jobs for PHSM and SHSM

### DIFF
--- a/charts/burpsuite/Chart.yaml
+++ b/charts/burpsuite/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: burpsuite
 description: Scan it all. With the enterprise-enabled dynamic web vulnerability scanner.
 type: application
-version: 0.3.1
+version: 0.3.2
 kubeVersion: ">=1.24.0-0"
 keywords:
   - burpsuite

--- a/charts/burpsuite/templates/enterprise/env-configmap.yaml
+++ b/charts/burpsuite/templates/enterprise/env-configmap.yaml
@@ -9,6 +9,8 @@ metadata:
 data:
   BSEE_SAAS_PHSM_MAX_CONCURRENT_SCANS: {{ .Values.enterprise.phsmMaxConcurrentScan | quote }}
   BSEE_SAAS_PHSM_MAX_CONCURRENT_CONNECTION_CHECKS: {{ .Values.enterprise.phsmMaxConcurrentConnectionChecks | quote }}
+  BSEE_SAAS_PHSM_MAX_CONCURRENT_BURP_AI_JOBS: {{ .Values.enterprise.phsmMaxConcurrentBurpAiJobs | quote }}
+  BSEE_SHSM_MAX_CONCURRENT_BURP_AI_JOBS: {{ .Values.enterprise.shsmMaxConcurrentBurpAiJobs | quote }}
 {{- with include "burpsuite.database.url" . }}
   BSEE_ADMIN_REPOSITORY_URL: {{ . }}
   BSEE_AGENT_REPOSITORY_URL: {{ . }}

--- a/charts/burpsuite/values.yaml
+++ b/charts/burpsuite/values.yaml
@@ -59,6 +59,8 @@ enterprise:
     memory: 1.8Gi
   phsmMaxConcurrentScan: 300
   phsmMaxConcurrentConnectionChecks: 50
+  phsmMaxConcurrentBurpAiJobs: 500
+  shsmMaxConcurrentBurpAiJobs: 1
   serverJavaOpts: -Xms1g -Xmx1g
   burpJavaOpts: -Xms256m -Xmx256m
 


### PR DESCRIPTION
Set limit of max concurrent BURP AI jobs for portswigger-hosted scanning machines (PHSM) and self-hosted scanning machines (SHSM). 

These limits introduce the following:
1. In case of PHSM - a cap on concurrently running k8s pods performing AI-related processing
2. In case of SHSM - a cap on concurrently running burp pro processes performing AI-related processing