### PR TITLE
Increase period of startupProbe in enterprise-server

### DIFF
--- a/charts/burpsuite/Chart.yaml
+++ b/charts/burpsuite/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: burpsuite
 description: Scan it all. With the enterprise-enabled dynamic web vulnerability scanner.
 type: application
-version: 0.3.1
+version: 0.3.2
 kubeVersion: ">=1.24.0-0"
 keywords:
   - burpsuite

--- a/charts/burpsuite/templates/enterprise/_containertemplate.tpl
+++ b/charts/burpsuite/templates/enterprise/_containertemplate.tpl
@@ -21,7 +21,7 @@
       port: ent-health
       path: /health/readiness
     failureThreshold: 60
-    periodSeconds: 5
+    periodSeconds: 10
     timeoutSeconds: 2
   livenessProbe:
     httpGet:


### PR DESCRIPTION
The enterprise-server runs DB schema migrations on update which can take a very long time for deployments with large amount of data in the DB. 

DB schema migrations can take so long that the startup probe exceeds the failure threshold and kills the enterprise-server in the middle of the migrations leading to an orphaned schema migration lock in the DB which prevents consequent enterprise-server startups from running migrations. This leads to enterprise-server getting stuck in a loop of continuously coming up, failing to run migrations and dying. 

This PR effectively raises the timeout from 5 minutes to 10 minutes by doubling the startup probe's check period in order to allow the migrations to complete before enterprise-server is killed by the probe timeout.