### PR TITLE
Add Compass component descriptor

### DIFF
--- a/compass.yml
+++ b/compass.yml
@@ -1,5 +1,6 @@
 name: helm-charts
 slug: portswigger-cloud-helm-charts
+description: 'Helm charts for Burp Enterprise used on-prem and in the cloud'
 configVersion: 1
 typeId: CLOUD_RESOURCE
 ownerId: 'ari:cloud:identity::team/793aa195-1b2d-44e4-8fd5-6aa1f3c273e9'

--- a/compass.yml
+++ b/compass.yml
@@ -1,0 +1,12 @@
+name: helm-charts
+slug: portswigger-cloud-helm-charts
+configVersion: 1
+typeId: CLOUD_RESOURCE
+ownerId: 'ari:cloud:identity::team/793aa195-1b2d-44e4-8fd5-6aa1f3c273e9'
+fields:
+  lifecycle: Active
+  tier: 1
+  isMonorepoProject: false
+links:
+  - type: REPOSITORY
+    url: 'https://github.com/portswigger-cloud/helm-charts'


### PR DESCRIPTION
Adds `compass.yml` so this repo's Compass component is defined as code rather than drifting from an auto-import.

Sets `typeId`, `ownerId` (Technology), and the built-in `lifecycle` / `tier` fields.

**Why:** Compass currently types every platform repo as `SERVICE` regardless of what it actually is, so activity and deployment scorecards fire on repos where "no commits/deploys this month" is meaningless — config stores, docs, legacy. Typing and tiering them correctly is what lets those criteria be scoped sensibly.

Source of truth: the platform repo audit — `Kind` maps to `typeId`, criticality to `tier`, `Status` to `lifecycle`.
