### PR TITLE
Make startupProbe configurable for enterprise and web

### DIFF
--- a/charts/burpsuite/Chart.yaml
+++ b/charts/burpsuite/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: burpsuite
 description: Scan it all. With the enterprise-enabled dynamic web vulnerability scanner.
 type: application
-version: 0.3.3
+version: 0.3.4
 kubeVersion: ">=1.24.0-0"
 keywords:
   - burpsuite

--- a/charts/burpsuite/templates/enterprise/_containertemplate.tpl
+++ b/charts/burpsuite/templates/enterprise/_containertemplate.tpl
@@ -20,9 +20,9 @@
     httpGet:
       port: ent-health
       path: /health/readiness
-    failureThreshold: 60
-    periodSeconds: 10
-    timeoutSeconds: 2
+    failureThreshold: {{ .Values.enterprise.startupProbe.failureThreshold }}
+    periodSeconds: {{ .Values.enterprise.startupProbe.periodSeconds }}
+    timeoutSeconds: {{ .Values.enterprise.startupProbe.timeoutSeconds }}
   livenessProbe:
     httpGet:
       port: ent-health

--- a/charts/burpsuite/templates/web/_containertemplate.tpl
+++ b/charts/burpsuite/templates/web/_containertemplate.tpl
@@ -20,9 +20,9 @@
     httpGet:
       port: web-health
       path: /health/readiness
-    failureThreshold: 60
-    periodSeconds: 5
-    timeoutSeconds: 2
+    failureThreshold: {{ .Values.web.startupProbe.failureThreshold }}
+    periodSeconds: {{ .Values.web.startupProbe.periodSeconds }}
+    timeoutSeconds: {{ .Values.web.startupProbe.timeoutSeconds }}
   livenessProbe:
     httpGet:
       port: web-health

--- a/charts/burpsuite/values.yaml
+++ b/charts/burpsuite/values.yaml
@@ -57,6 +57,12 @@ enterprise:
   resources:
     cpu: 200m
     memory: 1.8Gi
+
+  startupProbe:
+    failureThreshold: 60
+    periodSeconds: 10
+    timeoutSeconds: 2
+
   phsmMaxConcurrentScan: 300
   phsmMaxConcurrentConnectionChecks: 50
   phsmMaxConcurrentBurpAiJobs: 500
@@ -109,6 +115,12 @@ web:
   resources:
     cpu: 200m
     memory: 1Gi
+
+  startupProbe:
+    failureThreshold: 60
+    periodSeconds: 5
+    timeoutSeconds: 2
+
   ipRangesAppUrl: https://ip-ranges.portswigger-dev.cloud
   serverJavaOpts: -Xms512m -Xmx512m
 


### PR DESCRIPTION
## What

Moves the `startupProbe` timings for the `enterprise` and `web` containers out of the container templates and into `values.yaml`:

```yaml
enterprise:
  startupProbe:
    failureThreshold: 60
    periodSeconds: 10
    timeoutSeconds: 2

web:
  startupProbe:
    failureThreshold: 60
    periodSeconds: 5
    timeoutSeconds: 2
```

Current hardcoded numbers are preserved as the defaults, so rendering with default values is unchanged.

`httpGet` (port name and path) stays hardcoded — that's an app contract rather than something an operator should tune. `livenessProbe` and `readinessProbe` are untouched.

## Why

So that we can use XR composition to override these values and guarantee that Crossplane won't roll them back.

## Verification

- `helm template` with default values renders probe blocks byte-identical to before
- Overrides via `--set enterprise.startupProbe.periodSeconds=15` etc. apply correctly
- `helm lint` passes